### PR TITLE
Include ruby shared lib

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     chdir={{ workspace }}/ruby-{{ ruby_version }}
     creates=/usr/local/bin/ruby
   with_items:
-    - ./configure
+    - ./configure --enable-shared
     - make
     - sudo make install
 


### PR DESCRIPTION
Some gems require the libruby.so files. I tried real hard to write a command to copy the static libs, but wasn't able to figure it out (wildcards are hard, and I'm still learning ansible).
