### PR TITLE
added user install variable to gems installation as variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ ruby_download_url: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz
 ruby_version: 2.2.2
 
 ruby_rubygems_package_name: rubygems
+user_install: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,5 +19,5 @@
   when: ruby_install_from_source == true
 
 - name: Install configured gems.
-  gem: "name={{ item }} state=present"
+  gem: "name={{ item }} state=present user_install={{ user_install }}"
   with_items: ruby_install_gems


### PR DESCRIPTION
The gems specified ruby_install_gems variable are installed in user's home dir in .gem folder.
By default they should be added to /usr/local/bin.
I have added this as variable so that users can choose where to install it
