### PR TITLE
fix ruby source extension bug

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -27,11 +27,11 @@
 - name: Download ruby.
   get_url:
     url: "{{ ruby_download_url }}"
-    dest: "{{ workspace }}/ruby-{{ ruby_version }}.tar"
+    dest: "{{ workspace }}/ruby-{{ ruby_version }}.tar.gz"
 
 - name: Extract ruby.
   unarchive:
-    src: "{{ workspace }}/ruby-{{ ruby_version }}.tar"
+    src: "{{ workspace }}/ruby-{{ ruby_version }}.tar.gz"
     dest: "{{ workspace }}/"
     copy: no
 


### PR DESCRIPTION
The default name for the ruby source package is http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz but the dest parameter is `"{{ workspace }}/ruby-{{ ruby_version }}.tar"` which does not work.