### PR TITLE
ruby_install_gems_user falls back in Ansible >= 2 instead of failing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,25 @@
 - name: Define ruby_install_gems_user.
   set_fact:
     ruby_install_gems_user: "{{ ansible_ssh_user }}"
-  when: ruby_install_gems_user is not defined
+  when: (ruby_install_gems_user is not defined) and
+        (ansible_ssh_user is defined and ansible_version.major < 2)
+
+- name: Define ruby_install_gems_user.
+  set_fact:
+    ruby_install_gems_user: "{{ ansible_user }}"
+  when: (ruby_install_gems_user is not defined) and
+        (ansible_user is defined and ansible_version.major >= 2)
+
+- name: Define ruby_install_gems_user.
+  set_fact:
+    ruby_install_gems_user: "{{ ansible_user_id }}"
+  when: (ruby_install_gems_user is not defined) and
+        (
+          (ansible_version.major >= 2) and
+          (ansible_ssh_user is not defined) and
+          (ansible_user is not defined) and
+          (ansible_user_id is defined)
+        )
 
 - name: Install configured gems.
   gem: "name={{ item }} state=present"


### PR DESCRIPTION
Resolves #24

The goal of this pull request is to ensure that the `Define ruby_install_gems_user` task doesn't fail when using Ansible >= 2, and not supplying `ansible_user` or `ruby_install_gems_user` values. Falling back to the current user (`ansible_user_id`) felt like a sensible default, but I'd be interested to hear if there are better options.