### PR TITLE
Added build-essential

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -13,6 +13,7 @@
 - name: Install packages required to build ruby (Debian).
   apt: "name={{ item }} state=present"
   with_items:
+    - build-essential
     - zlib1g-dev
     - libssl-dev
     - libyaml-dev


### PR DESCRIPTION
Installation fails if build-essential is not installed, please add it.