### PR TITLE
add switch for install bundler

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,5 @@ ruby_download_url: http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz
 ruby_version: 2.3.0
 
 ruby_rubygems_package_name: rubygems
+
+ruby_install_bundler: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
 # Install Bundler and configured gems.
 - name: Install Bundler.
   gem: name=bundler state=present user_install=no
+  when: ruby_install_bundler
 
 - name: Define ruby_install_gems_user.
   set_fact:


### PR DESCRIPTION
Hi

I add a switch for install bundler, because we cannot install any gem by normal way in China.

After this modification, I can install bundler and some gems like this

```yaml
---
- hosts: server
  roles:
    - ansible-role-ruby
      ruby_install_from_source: True
      ruby_version: 2.2.2
      ruby_download_url: http://cache.ruby-lang.org/pub/ruby/ruby-2.2.2.tar.gz
      ruby_install_bundler: False
      ruby_install_gems: []

  tasks:
    - name: 'Replace gem source for user'
      shell: gem sources --add https://gems.ruby-china.org/ --remove https://rubygems.org/
      become: yes
      become_user: "{{ ansible_ssh_user }}"

    - name: 'Replace gem source for root'
      shell: gem sources --add https://gems.ruby-china.org/ --remove https://rubygems.org/
      become: yes
      become_user: "root"

    - name: Install Bundler.
      gem: name=bundler state=present user_install=no

    - name: Install configured gems.
      gem: "name={{ item }} state=present"
      become: yes
      become_user: "{{ ansible_ssh_user }}"
      with_items:
        - pry

```

Please review it, thanks.
