### PR TITLE
Enable ruby updates from source

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,8 @@ ruby_install_gems_user: "{{ ansible_user }}"
 # If set to TRUE, ruby will be installed from source, using the version set with
 # the 'ruby_version' variable instead of using a package.
 ruby_install_from_source: false
-ruby_download_url: http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz
 ruby_version: 2.3.0
+ruby_download_url: "http://cache.ruby-lang.org/pub/ruby/{{ ruby_version | regex_replace('^([0-9]+.[0-9]+).*$', '\\1') }}/ruby-{{ ruby_version }}.tar.gz"
 
 # Default should usually work, but this will be overridden on Ubuntu 14.04.
 ruby_rubygems_package_name: rubygems

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -26,26 +26,48 @@
     - libgdbm-dev
   when: ansible_os_family == 'Debian'
 
+- name: Check ruby version.
+  command: bash -lc "ruby --version"
+  register: current_ruby_version
+  failed_when: false
+  changed_when: false
+  always_run: true
+
 - name: Download ruby.
   get_url:
     url: "{{ ruby_download_url }}"
     dest: "{{ workspace }}/ruby-{{ ruby_version }}.tar.gz"
+  when: "'{{ ruby_version }}' not in current_ruby_version.stdout"
 
 - name: Extract ruby.
   unarchive:
     src: "{{ workspace }}/ruby-{{ ruby_version }}.tar.gz"
     dest: "{{ workspace }}/"
     copy: no
+  when: "'{{ ruby_version }}' not in current_ruby_version.stdout"
+
+- name: Remove old ruby version
+  file:
+    path: "/usr/local/bin/{{ item }}"
+    state: absent
+  with_items:
+    - erb
+    - gem
+    - irb
+    - rake
+    - rdoc
+    - ruby 
+  when: "'{{ ruby_version }}' not in current_ruby_version.stdout"
 
 - name: Build ruby.
   command: >
     {{ item }}
     chdir={{ workspace }}/ruby-{{ ruby_version }}
-    creates=/usr/local/bin/ruby
   with_items:
     - ./configure --enable-shared
     - make
     - make install
+  when: "'{{ ruby_version }}' not in current_ruby_version.stdout"
 
 - name: Add ruby symlinks.
   file:


### PR DESCRIPTION
Previously functionality did not check the ruby version.
This change will allow the version to be updated if a different version is supplied.