### PR TITLE
Fixes #43 : install_from_source.yml always skipped

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,17 +2,17 @@
 # Include OS-specific installation tasks.
 - include: setup-RedHat.yml
   when:
-    - ruby_install_from_source == False
+    - not ruby_install_from_source
     - ansible_os_family == 'RedHat'
 
 - include: setup-Debian.yml
   when:
-    - ruby_install_from_source == False
+    - not ruby_install_from_source
     - ansible_os_family == 'Debian'
 
 # Install ruby from source when ruby_install_from_source is true.
 - include: install-from-source.yml
-  when: ruby_install_from_source == True
+  when: ruby_install_from_source
 
 - name: Add user installed RubyGems bin directory to global $PATH.
   copy:


### PR DESCRIPTION
The issue was the the ruby_install_from_source where comparison was
always being evaluated as false.

I just changed to to a native boolean comparison to avoid casting as I think
that it looks tidier that was even if it is less readable.