### PR TITLE
Fix failure to load rubygems library

### DIFF
--- a/files/rubygems.sh
+++ b/files/rubygems.sh
@@ -1,3 +1,3 @@
 if which ruby >/dev/null && which gem >/dev/null; then
-    PATH="$(ruby -rubygems -e 'puts Gem.user_dir')/bin:$PATH"
+    PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
 fi

--- a/files/rubygems.sh
+++ b/files/rubygems.sh
@@ -1,3 +1,3 @@
 if which ruby >/dev/null && which gem >/dev/null; then
-    PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
+    PATH="$(ruby -rrubygems -e 'puts Gem.user_dir')/bin:$PATH"
 fi


### PR DESCRIPTION
Using Ubuntu 18.04 & Ruby 2.5.1p57, I'm getting the following error:

```
Traceback (most recent call last):
	1: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- ubygems (LoadError)
```

This pull request should fix that issue.