### PR TITLE
Fix command-line-args '-rubygems' won't work for ruby 2.5.1

### DIFF
--- a/files/rubygems.sh
+++ b/files/rubygems.sh
@@ -1,3 +1,3 @@
 if which ruby >/dev/null && which gem >/dev/null; then
-    PATH="$(ruby -rubygems -e 'puts Gem.user_dir')/bin:$PATH"
+    PATH="$(ruby -r 'rubygems' -e 'puts Gem.user_dir')/bin:$PATH"
 fi


### PR DESCRIPTION
### Issue
When I tried to install ruby 2.5.1 from source code, it did not complete and showed below error:
```
fatal: [192.168.111.22]: FAILED! => {
    "msg": "Timeout (12s) waiting for privilege escalation prompt: \u001b[1mTraceback\u001b[m (most recent call last):\r\n\t1: from /opt/rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'\r\n/opt/rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': \u001b[1mcannot load such file -- ubygems (\u001b[1;4mLoadError\u001b[m\u001b[1m)\r\n"
}
```

#### Playbook
```yaml
- hosts: app
  vars:
    ruby_version: 2.5.1
    ruby_install_from_source: true
    ruby_download_url: https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz
  roles:
    - geerlingguy.ruby
```

#### Reason
Command line arguments, ```-rubygems``` in files/rubygems.sh is not allowed for ruby 2.5.0.

files/rubygems.sh
```bash
if which ruby >/dev/null && which gem >/dev/null; then
    PATH="$(ruby -rubygems -e 'puts Gem.user_dir')/bin:$PATH"
fi
```

It seems earlier version of ruby allows.
```
$ ruby -v
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin16]
$ ruby -rubygems -e 'puts Gem.user_dir'
/Users/bookpro/.gem/ruby/2.3.0

$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]
$ ruby -rubygems -e 'puts Gem.user_dir'
/Users/bookpro/.gem/ruby/2.4.0

$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]
$ ruby -rubygems -e 'puts Gem.user_dir'
Traceback (most recent call last):
	1: from /Users/bookpro/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Users/bookpro/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- ubygems (LoadError)
```
