### PR TITLE
Adding no_log: True to certain tasks

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -5,6 +5,7 @@
   when: ruby_build_packages is not defined
 
 - name: Install packages required to build ruby.
+  no_log: true
   yum:
     name: "{{ ruby_build_packages }}"
     state: present
@@ -15,6 +16,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install packages required to build ruby (Debian).
+  no_log: true
   apt:
     name: "{{ ruby_build_packages }}"
     state: present
@@ -32,6 +34,7 @@
     copy: false
 
 - name: Build ruby.
+  no_log: true
   command: >
     {{ item }}
     chdir={{ workspace }}/ruby-{{ ruby_version }}


### PR DESCRIPTION
- Adding of `no_log: true` to noisy tasks

Note: We are pulling this repo and it's quite noisy on the CI system we use, and if it fails, it should give us log output anyway.