### PR TITLE
Allow specific bundler version to be installed 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@ workspace: /root
 
 # Whether this role should install Bundler.
 ruby_install_bundler: true
+# Defaults to latest Bundler release. Set the 'ruby_bundler_version' variable
+# to install a specififc version of Bundler
+ruby_bundler_version: ''
 
 # A list of Ruby gems to install.
 ruby_install_gems: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
     name: bundler
     version: "{{ ruby_bundler_version }}"
     state: present
-    user_install: no
+    user_install: false
   when: ruby_install_bundler
 
 - name: Install configured gems.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,11 @@
 
 # Install Bundler and configured gems.
 - name: Install Bundler.
-  gem: name=bundler state=present user_install=no
+  gem:
+    name: bundler
+    version: "{{ ruby_bundler_version }}"
+    state: present
+    user_install: no
   when: ruby_install_bundler
 
 - name: Install configured gems.


### PR DESCRIPTION
I had previously hit an issue using this role when [`Bundler 2.0.0`](https://github.com/bundler/bundler/releases/tag/v2.0.0) was released because I am using it to install an older version of Ruby from source. I ended up in the situation where I needed to manually upgrade RubyGems with `gem update --system` then run ansible again. Setting the `ruby_bundler_version` allowed me to purposely install `Bundler 1.17.3` instead. [`Bundler 2.0.1`](https://github.com/bundler/bundler/releases/tag/v2.0.1) was then released which helped mitigate this by relaxing the RubyGems requirement to `>= 2.5.0`. 

I still think having the ability to install a specific version of Bundler is nice to have though.

ref:
https://github.com/bundler/bundler/issues/6866
https://github.com/bundler/bundler/pull/6867
