### PR TITLE
Enable readline.rb on RedHat/Centos

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,3 +8,4 @@ __ruby_build_packages:
   - '@development'
   - zlib-devel
   - openssl-static
+  - readline-devel


### PR DESCRIPTION
This adds the OS readline-devel package, which, when present at ruby build time, enables readline.rb. That allows up-arrow to search backwards through history in irb, and avoids some error I won't pretend to understand that comes up when running rails via passenger, but which mentions a lack of readline.rb

#9 added readline for ubuntu-based OSes, this is the equivalent for RedHat-based OSes