### PR TITLE
abb bundler version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The location where temporary files will be downloaded in preparation for Ruby in
 
 Whether this role should install [Bundler](http://bundler.io/).
 
+    ruby_bundler_version: 2.0.1
+
+The version of Bundler that will be installed.
+
     ruby_install_gems: []
 
 A list of Ruby gems to install (just the name of the gem to be installed). This is meant as a simple convenience, and will only install the latest version of the gem. If you need to install gems with more options or specificity, you can do so elsewhere in your playbook.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ workspace: /root
 
 # Whether this role should install Bundler.
 ruby_install_bundler: true
-
+ruby_bundler_version: 2.0.1
 # A list of Ruby gems to install.
 ruby_install_gems: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 
 # Install Bundler and configured gems.
 - name: Install Bundler.
-  gem: name=bundler state=present user_install=no
+  gem: name=bundler state=present version={{ ruby_bundler_version }} user_install=no
   when: ruby_install_bundler
 
 - name: Install configured gems.


### PR DESCRIPTION
Hi there,

I use this playbook for install an old Ruby and get error because of Bundler version, so i add this variable to support bundler version.

`ruby_bundler_version: 2.0.1`

BR,
Meysam.