### PR TITLE
Change default RedHat package '@development' to '@Development tools' to support Fedora

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,8 +3,8 @@ __ruby_packages:
   - ruby
   - ruby-devel
   - "{{ ruby_rubygems_package_name }}"
-  - '@development'
+  - '@Development tools'
 __ruby_build_packages:
-  - '@development'
+  - '@Development tools'
   - zlib-devel
   - openssl-static


### PR DESCRIPTION
This PR replaces the package name '@development' with '@Development tools' for RedHat systems.

The alias '@development' does not exist on Fedora; instead, '@development-tools' is used. This name difference causes Fedora systems to fail to complete successfully without providing correct package names with the `ruby_packages` and `ruby_build_packages` variables.

This change aims to broaden out-of-the-box support to include Fedora. That is, to install ruby using default values.