### PR TITLE
support dry run 

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -31,7 +31,9 @@
   register: ruby_version_marker
 
 - name: Download, extract, and install ruby
-  when: not ruby_version_marker.stat.exists
+  when:
+    - not ruby_version_marker.stat.exists
+    - not ansible_check_mode
   block:
     - name: Download ruby.
       get_url:


### PR DESCRIPTION
when use `dry-run`, `Extract ruby` task will be failed. 
So I add a "not ansible_check_mode" in when statement.


```
"dry-run-ansible": TASK [geerlingguy.ruby : Extract ruby.] ****************************************
"dry-run-ansible": fatal: [development-1]: FAILED! => {"changed": false, "msg": "Source '/tmp/ruby-3.0.2.tar.gz' does not exist"}
```