### PR TITLE
Add bindir-parameter to ruby_install_gems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
     name: "{{ item.name | default(item) }}"
     version: "{{ item.version | default(omit) }}"
     user_install: "{{ item.user_install | default(omit) }}"
+    bindir: "{{ item.bindir | default(omit) }}"
     state: present
   become: true
   become_user: "{{ ruby_install_gems_user }}"


### PR DESCRIPTION
Hey :wave: 
we would need the `bindir` parameter for ruby_install_gems.
thanks and best regards